### PR TITLE
fix: update InputField query to handle globals

### DIFF
--- a/src/fields/PublishDate/components/InputField.tsx
+++ b/src/fields/PublishDate/components/InputField.tsx
@@ -37,10 +37,19 @@ const InputField: (datePickerProps: ConditionalDateProps) => React.FC<Props> =
     // verify that scheduled posts actually have a job
     const doc = useDocumentInfo()
     const [queued, setQueued] = useState<boolean>()
+
     useEffect(() => {
       async function verifySchedule() {
+        const isGlobal = doc?.global !== undefined
+
         try {
-          const qs = {
+          const qs = isGlobal ? {
+            where: {
+              global: {
+                equals: doc.global?.slug
+              }
+            }
+          } : {
             where: {
               and: [
                 {


### PR DESCRIPTION
fixes #11 

forgot to update the query logic in the `publish_date` input field for globals, causing it to display incorrect error messages