### PR TITLE
feat: `SafeRelationship` field

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,30 @@ This value will also be passed to the `DatePicker` component. Defaults to 5 mins
 Custom configuration for the scheduled posts collection that gets merged with the defaults.
 
 
+## Utils
+
+### `SafeRelationship`
+
+Drop-in replacement for the default [`relationship` field](https://payloadcms.com/docs/fields/relationship) to prevent users from publishing documents that have references to other docs that are still in draft / scheduled mode.
+
+```ts
+import type { Field } from 'payload'
+import { SafeRelationship } from 'payload-plugin-scheduler'
+
+const example: Field = SafeRelationship({
+  name: 'featured_content',
+  relationTo: ['posts', 'pages'],
+  hasMany: true,
+})
+```
+
 ## Approach
 
-In a nutshell, the plugin creates a `publish_date` field that it uses to determine whether a pending draft update needs to be scheduled.
+In a nutshell, the plugin creates a `publish_date` field that it uses to determine whether a pending draft update needs to be scheduled. If a draft document is saved with a `publish_date` that's in the future, it will be scheduled and automatically published on that date.
 
 ### `publish_date`
 
-Custom Datetime field added to documents in enabled collections.
-Includes custom `Field` and `Cell` components that include schedule status in the client-side UI.
+Datetime field added to enabled collections. Custom `Field` and `Cell` components display the schedule status in the client-side UI.
 
 ### `scheduled_posts`
 
@@ -82,3 +98,5 @@ A configurable timer checks for any posts to be scheduled in the upcoming interv
 * This plugin doesn't support Payload 3.0 beta. I intend to update it once 3.0 is stable, but it'll require substantial re-architecting to work in a serverless environment.
 
 * There's no logic in place to dedupe schedules across multiple instances of a single app (see https://github.com/wkentdag/payload-plugin-scheduler/issues/9)
+
+* There's no logic in place to automatically publish any pending scheduled posts that weren't published due to server downtime. 

--- a/dev/src/collections/Basics.ts
+++ b/dev/src/collections/Basics.ts
@@ -1,0 +1,16 @@
+import { type CollectionConfig } from 'payload/types'
+
+const Basics: CollectionConfig = {
+  slug: 'basics',
+  admin: {
+    useAsTitle: 'title',
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+    },
+  ],
+}
+
+export default Basics

--- a/dev/src/collections/Pages.ts
+++ b/dev/src/collections/Pages.ts
@@ -1,4 +1,6 @@
 import { type CollectionConfig } from 'payload/types'
+// @ts-expect-error
+import { SafeRelationship } from '../../../src'
 
 // Example Collection - For reference only, this must be added to payload.config.ts to be used.
 const Pages: CollectionConfig = {
@@ -16,6 +18,32 @@ const Pages: CollectionConfig = {
       name: 'content',
       type: 'textarea',
     },
+    // @ts-expect-error @TODO fix clashing react/payload deps
+    SafeRelationship({
+      relationTo: 'posts',
+      name: 'featured_post',
+      label: 'Featured Post',
+      hasMany: false,
+    }),
+    // @ts-expect-error @TODO fix clashing react/payload deps
+    SafeRelationship({
+      relationTo: 'pages',
+      name: 'related_pages',
+      label: 'Related Pages',
+      hasMany: true,
+    }),
+    // @ts-expect-error @TODO fix clashing react/payload deps
+    SafeRelationship({
+      relationTo: ['pages', 'basics'],
+      name: 'mixed_relationship',
+      hasMany: true,
+    }),
+    // @ts-expect-error @TODO fix clashing react/payload deps
+    SafeRelationship({
+      relationTo: ['pages', 'posts'],
+      name: 'polymorphic',
+      hasMany: true,
+    })
   ],
 }
 

--- a/dev/src/collections/PagesWithExtraHooks.ts
+++ b/dev/src/collections/PagesWithExtraHooks.ts
@@ -1,5 +1,6 @@
 import type { CollectionAfterChangeHook, CollectionConfig } from 'payload/types'
 import type { Pageswithextrahook } from 'payload/generated-types'
+import Pages from './Pages'
 // @ts-expect-error
 import { debug } from '../../../src/util'
 
@@ -20,22 +21,13 @@ export const ExtraHook: CollectionAfterChangeHook<Pageswithextrahook> = async ({
 }
 
 const PagesWithExtraHooks: CollectionConfig = {
+  ...Pages,
   slug: 'pageswithextrahooks',
-  admin: {
-    useAsTitle: 'title',
-  },
-  versions: { drafts: true },
   hooks: {
     afterChange: [
       ExtraHook
     ]
-  },
-  fields: [
-    {
-      name: 'title',
-      type: 'text',
-    },
-  ]
+  }
 }
 
 export default PagesWithExtraHooks

--- a/dev/src/collections/PagesWithExtraHooks.ts
+++ b/dev/src/collections/PagesWithExtraHooks.ts
@@ -1,6 +1,5 @@
 import type { CollectionAfterChangeHook, CollectionConfig } from 'payload/types'
 import type { Pageswithextrahook } from 'payload/generated-types'
-import Pages from './Pages'
 // @ts-expect-error
 import { debug } from '../../../src/util'
 
@@ -21,13 +20,22 @@ export const ExtraHook: CollectionAfterChangeHook<Pageswithextrahook> = async ({
 }
 
 const PagesWithExtraHooks: CollectionConfig = {
-  ...Pages,
   slug: 'pageswithextrahooks',
+  admin: {
+    useAsTitle: 'title',
+  },
+  versions: { drafts: true },
   hooks: {
     afterChange: [
       ExtraHook
     ]
-  }
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+    },
+  ]
 }
 
 export default PagesWithExtraHooks

--- a/dev/src/collections/Posts.ts
+++ b/dev/src/collections/Posts.ts
@@ -3,6 +3,7 @@ import Pages from './Pages'
 
 const Posts: CollectionConfig = {
   ...Pages,
+  fields: [Pages.fields[0]],
   slug: 'posts',
 }
 

--- a/dev/src/collections/Posts.ts
+++ b/dev/src/collections/Posts.ts
@@ -1,10 +1,17 @@
 import { type CollectionConfig } from 'payload/types'
-import Pages from './Pages'
 
 const Posts: CollectionConfig = {
-  ...Pages,
-  fields: [Pages.fields[0]],
   slug: 'posts',
+  admin: {
+    useAsTitle: 'title',
+  },
+  versions: { drafts: true },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+    },
+  ],
 }
 
 export default Posts

--- a/dev/src/collections/Users.ts
+++ b/dev/src/collections/Users.ts
@@ -7,6 +7,10 @@ const Users: CollectionConfig = {
     useAsTitle: 'email',
   },
   fields: [
+    {
+      name: 'name',
+      type: 'text',
+    }
     // Email added by default
     // Add more fields as needed
   ],

--- a/dev/src/payload.base.config.ts
+++ b/dev/src/payload.base.config.ts
@@ -11,6 +11,7 @@ import PagesWithExtraHooks from "./collections/PagesWithExtraHooks";
 // @ts-expect-error
 import { ScheduledPostPlugin } from '../../src'
 import Home from "./globals/Home";
+import Basics from "./collections/Basics";
 
 export const INTERVAL = 1
 
@@ -35,7 +36,7 @@ export const baseConfig: Omit<Config, 'db'> = {
     },
   },
   editor: slateEditor({}),
-  collections: [Pages, PagesWithExtraHooks, Posts, Users],
+  collections: [Basics, Pages, PagesWithExtraHooks, Posts, Users],
   globals: [Home],
   typescript: {
     outputFile: path.resolve(__dirname, 'payload-types.ts'),

--- a/dev/test/safeRelationship.spec.ts
+++ b/dev/test/safeRelationship.spec.ts
@@ -1,0 +1,213 @@
+import { addMinutes, subMinutes } from "date-fns"
+import type { Payload } from "payload"
+
+describe('SafeRelationshipField', () => {
+  const payload = globalThis.payloadClient as Payload
+
+  describe('false positives', () => {
+    test('published docs', async () => {
+      const publishedPost = await payload.create({
+        collection: 'posts',
+        data: {
+          title: 'published',
+          publish_date: subMinutes(new Date(), 10).toISOString(),
+          _status: 'published',
+        }
+      })
+      
+      const published = await payload.create({
+        collection: 'pages',
+        data: {
+          title: 'published',
+          featured_post: publishedPost.id,
+          _status: 'published',
+        }
+      })
+  
+      expect(published._status).toBe('published')
+      expect(published.featured_post.id).toEqual(publishedPost.id)
+    })
+
+    test('draft docs', async () => {
+      const scheduledPost = await payload.create({
+        collection: 'posts',
+        data: {
+          title: 'scheduled',
+          publish_date: addMinutes(new Date(), 10).toISOString(),
+          _status: 'draft',
+        }
+      })
+  
+      const draftPage = await payload.create({
+        collection: 'pages',
+        data: {
+          title: 'second page',
+          featured_post: scheduledPost.id,
+          _status: 'draft',
+        }
+      })
+  
+      expect(draftPage._status).toBe('draft')
+      expect(draftPage.featured_post.id).toBe(scheduledPost.id)
+    })
+
+    test('polymorphic field', async () => {
+      const page = await payload.create({
+        collection: 'pages',
+        data: {
+          title: 'page',
+          _status: 'published',
+        }
+      })
+  
+      const post = await payload.create({
+        collection: 'posts',
+        data: {
+          title: 'published',
+          _status: 'published'
+        }
+      })
+
+      await expect(payload.create({
+        collection: 'pages',
+        data: {
+          title: 'mixed',
+          polymorphic: [page.id, post.id],
+          _status: 'published',
+        }
+      })).resolves.not.toThrow()
+    })
+
+    test('mixed field', async () => {
+      const page = await payload.create({
+        collection: 'pages',
+        data: {
+          title: 'page',
+          _status: 'published',
+        }
+      })
+  
+      const basic = await payload.create({
+        collection: 'basics',
+        data: {
+          title: 'published',
+          _status: 'published'
+        }
+      })
+
+      await expect(payload.create({
+        collection: 'pages',
+        data: {
+          title: 'mixed',
+          polymorphic: [page.id, basic.id],
+          _status: 'published',
+        }
+      })).resolves.not.toThrow()
+    })
+  })
+
+  describe('errors', () => {
+    test('related document is scheduled after current document', async () => {
+      const scheduledPost = await payload.create({
+        collection: 'posts',
+        data: {
+          title: 'scheduled',
+          publish_date: addMinutes(new Date(), 10).toISOString(),
+          _status: 'draft',
+        }
+      })
+  
+      await expect(payload.create({
+        collection: 'pages',
+        data: {
+          title: 'second page',
+          featured_post: scheduledPost.id,
+          _status: 'published',
+        }
+      })).rejects.toThrow('The following field is invalid: featured_post')
+    })
+  })
+
+  test('one invalid document out of multiple', async () => {
+    const scheduledPage = await payload.create({
+      collection: 'pages',
+      data: {
+        title: 'scheduled',
+        publish_date: addMinutes(new Date(), 10).toISOString(),
+        _status: 'draft',
+      }
+    })
+
+    const publishedPage = await payload.create({
+      collection: 'pages',
+      data: {
+        title: 'published',
+        _status: 'published',
+      }
+    })
+
+    await expect(payload.create({
+      collection: 'pages',
+      data: {
+        title: 'multiple',
+        related_pages: [scheduledPage.id, publishedPage.id],
+        _status: 'published',
+      }
+    })).rejects.toThrow('The following field is invalid: related_pages')
+  })
+
+  test('one invalid document out of polymorphic', async () => {
+    const scheduledPage = await payload.create({
+      collection: 'pages',
+      data: {
+        title: 'scheduled',
+        publish_date: addMinutes(new Date(), 10).toISOString(),
+        _status: 'draft',
+      }
+    })
+
+    const publishedPost = await payload.create({
+      collection: 'posts',
+      data: {
+        title: 'published',
+        _status: 'published',
+      }
+    })
+
+    await expect(payload.create({
+      collection: 'pages',
+      data: {
+        title: 'multiple',
+        polymorphic: [scheduledPage.id, publishedPost.id],
+        _status: 'published',
+      }
+    })).rejects.toThrow('The following field is invalid: polymorphic')
+  })
+
+  test('one invalid document out of mixed', async () => {
+    const scheduledPage = await payload.create({
+      collection: 'pages',
+      data: {
+        title: 'scheduled',
+        publish_date: addMinutes(new Date(), 10).toISOString(),
+        _status: 'draft',
+      }
+    })
+
+    const basic = await payload.create({
+      collection: 'basics',
+      data: {
+        title: 'basic',
+      }
+    })
+
+    await expect(payload.create({
+      collection: 'pages',
+      data: {
+        title: 'multiple',
+        polymorphic: [scheduledPage.id, basic.id],
+        _status: 'published',
+      }
+    })).rejects.toThrow('The following field is invalid: mixed')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -26,11 +26,12 @@
   ],
   "scripts": {
     "build": "tsc",
+    "dev": "cd dev && yarn dev",
     "format": "prettier --write",
     "test": "cd dev && yarn test",
     "test:all": "run-p test:mongo test:postgres",
     "test:mongo": "PORT=3001 DATABASE_URI=mongodb://127.0.0.1/plugin-development PAYLOAD_CONFIG_PATH=src/payload.mongo.config.ts yarn test",
-    "test:postgres": "DATABASE_URI=postgres://127.0.0.1:5432/payload-plugin-scheduler PAYLOAD_CONFIG_PATH=src/payload.postgres.config.ts yarn test",
+    "test:postgres": "PORT=3002 DATABASE_URI=postgres://127.0.0.1:5432/payload-plugin-scheduler PAYLOAD_CONFIG_PATH=src/payload.postgres.config.ts yarn test",
     "lint": "eslint src",
     "lint:fix": "eslint --fix --ext .ts,.tsx src",
     "clean": "rimraf dist && rimraf dev/yarn.lock",

--- a/src/fields/SafeRelationship/index.ts
+++ b/src/fields/SafeRelationship/index.ts
@@ -13,6 +13,9 @@ type MaybeScheduledDoc = TypeWithID & Record<string, unknown> & {
 
 }
 
+/**
+ * Wrapper around the default `RelationshipField` that ensures "related" documents are published before the primary document
+ */
 export const SafeRelationship: (
   props: Omit<RelationshipField, 'type'>,
 ) => RelationshipField = (props) => {

--- a/src/fields/SafeRelationship/index.ts
+++ b/src/fields/SafeRelationship/index.ts
@@ -1,0 +1,124 @@
+import type { Payload } from 'payload'
+import type { SanitizedConfig } from 'payload/config'
+import type {
+  RelationshipField,
+  RelationshipValue,
+  Validate,
+} from 'payload/types'
+
+const SafeRelationshipField: (
+  props: Omit<RelationshipField, 'type'>,
+) => RelationshipField = (props) => {
+  const validate: Validate<RelationshipValue> = async (
+    value,
+    options,
+  ): Promise<string | true> => {
+    // first run user validate fn
+    if (props.validate) {
+      const validateRes = await props.validate(value, options)
+      if (validateRes !== true) {
+        return validateRes
+      }
+    }
+
+    const {
+      config,
+      data,
+      payload,
+    }: { config: SanitizedConfig; data: object; payload: Payload } = options
+
+    // can't run on the client
+    if (!payload) {
+      return true
+    }
+
+    // abort if the current document is a draft
+    if (data?._status === 'draft' && !data?.publish_date) {
+      return true
+    }
+
+    // cast relationTo to an array
+    const relationsTo = Array.isArray(props.relationTo)
+      ? props.relationTo
+      : [props.relationTo]
+
+    // build a list of collections we need to check draft status for
+    const relatedDraftCollections = []
+
+    relationsTo.forEach((name) => {
+      const collection = config.collections.find(({ slug }) => slug === name)
+      if (!!collection?.versions?.drafts) {
+        relatedDraftCollections.push(collection.slug)
+      }
+    })
+
+    // cast value to an array
+    const values = Array.isArray(value) ? value : [value]
+
+    // compile an array of related documents
+    const relatedDocs = await Promise.all(
+      values.map(async (v) => {
+        // naively assume that we're dealing with a simple (not polymorphic) relationship
+        // https://payloadcms.com/docs/fields/relationship#how-the-data-is-saved
+        let collection = props.relationTo as string
+        let id = v as string | number
+
+        // handle polymorphic relationships
+        if (typeof v === 'object') {
+          collection = v.relationTo
+          id = v.value
+        }
+
+        // ignore related docs w/o drafts
+        if (!relatedDraftCollections.includes(collection)) {
+          return null
+        }
+
+        const doc = await payload.findByID({
+          id,
+          collection,
+        })
+
+        return doc
+      }),
+    )
+
+    const invalidRelatedDocs = []
+
+    const publishDate =
+      data?._status === 'published' ? new Date() : new Date(data?.publish_date)
+
+    // loop over the related documents...
+    relatedDocs
+      // filter out invalid elements @TODO perform this step above in a `reduce`
+      .filter((doc) => {
+        return !!doc && doc?._status === 'draft'
+      })
+      // find any invalid publish_dates
+      .forEach((data) => {
+        const docPubDate = data.publish_date
+          ? new Date(data.publish_date)
+          : null
+        // console.log(docPubDate, publishDate, docPubDate >= publishDate)
+        if (!docPubDate || docPubDate >= publishDate) {
+          invalidRelatedDocs.push(data.id)
+        }
+      })
+
+    if (invalidRelatedDocs.length > 0) {
+      return `The following documents won't be published before this one: ${invalidRelatedDocs.join(', ')}. Please remove the publish_date from the current document, or change the publish_date on the related documents`
+    }
+
+    return true
+  }
+
+  const field: RelationshipField = {
+    type: 'relationship',
+    ...props,
+    validate,
+  } as RelationshipField
+
+  return field
+}
+
+export default SafeRelationshipField

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { ScheduledPostPlugin } from './plugin'
-export type { ScheduledPostConfig } from './types'
+export { SafeRelationship } from './fields/SafeRelationship'
+export type { ScheduledPostConfig, SafeRelationshipField } from './types'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig, ValueWithRelation } from 'payload/types'
+import type SafeRelationship from './fields/SafeRelationship'
 
 export interface ScheduledPostConfig {
   collections?: string[]
@@ -14,3 +15,5 @@ export interface ScheduledPost {
   date: string
   status: 'queued' | 'complete'
 }
+
+export type SafeRelationshipField = typeof SafeRelationship

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import type { CollectionConfig, ValueWithRelation } from 'payload/types'
-import type SafeRelationship from './fields/SafeRelationship'
+import type { SafeRelationship } from './fields/SafeRelationship'
 
 export interface ScheduledPostConfig {
   collections?: string[]


### PR DESCRIPTION
Adds a `SafeRelationship` utility field. Wraps existing relationship field with automatic validation to ensure you don't publish a document that has related documents that are still in draft / scheduled state.


- [x] basic functionality
- [x] get tests passing
- [x] better error message
- [x] documentation