### PR TITLE
feat: add `executionAccess` option, closes #20

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,20 @@ ScheduledPostPlugin({
 
 Your job queue cron interval should match this value, eg `autoRun: [{ cron: '*/5 * * * *' }]`.
 
+### `executionAccess?: 'user' | 'override'`
+
+Controls whose access permissions Payload uses when the scheduled publish job executes. Defaults to `user`.
+
+- `user` stores the authenticated scheduling user's ID on the job. Payload re-checks that user's current permissions at execution time. Scheduling without an authenticated user throws an error.
+- `override` omits the user from the job, causing Payload to execute it with access overridden.
+
+```ts
+ScheduledPostPlugin({
+  collections: ['posts'],
+  executionAccess: 'override',
+})
+```
+
 ### `publishDate?: object`
 
 Configure the generated publish-date field.

--- a/dev/src/collections/Posts.ts
+++ b/dev/src/collections/Posts.ts
@@ -1,4 +1,12 @@
-import { type CollectionConfig } from 'payload'
+import { type CollectionBeforeChangeHook, type CollectionConfig } from 'payload'
+
+const preventAuthenticatedPublish: CollectionBeforeChangeHook = ({ data, req }) => {
+  if (req.user && data._status === 'published') {
+    throw new Error('Authenticated test users cannot publish posts directly')
+  }
+
+  return data
+}
 
 const Posts: CollectionConfig = {
   slug: 'posts',
@@ -6,6 +14,9 @@ const Posts: CollectionConfig = {
     useAsTitle: 'title',
   },
   versions: { drafts: true },
+  hooks: {
+    beforeChange: [preventAuthenticatedPublish],
+  },
   fields: [
     {
       name: 'title',

--- a/dev/src/payload.base.config.ts
+++ b/dev/src/payload.base.config.ts
@@ -38,6 +38,7 @@ export const baseConfig: Omit<Config, 'db'> = {
   plugins: [
     ScheduledPostPlugin({
       collections: ['pages', 'posts', 'pageswithextrahooks'],
+      executionAccess: 'override',
       globals: ['home'],
       interval: 5,
     }),

--- a/dev/test/plugin.spec.ts
+++ b/dev/test/plugin.spec.ts
@@ -174,6 +174,91 @@ describe('Plugin tests', () => {
     expect(updatedTotalDocs).toBe(0)
   })
 
+  it('allows a restricted user to publish later through an override-access job', async () => {
+    const user = await payload.create({
+      collection: 'users',
+      data: {
+        email: `override-scheduler-${Date.now()}@example.com`,
+        password: 'test-password',
+      },
+    })
+
+    await expect(payload.create({
+      collection: 'posts',
+      data: {
+        title: 'direct publish is forbidden',
+        _status: 'published',
+      },
+      overrideAccess: false,
+      user,
+    })).rejects.toThrow('Authenticated test users cannot publish posts directly')
+
+    const pubDate = addSeconds(new Date(), 1)
+    const draft = await payload.create({
+      collection: 'posts',
+      data: {
+        title: 'override scheduled publish',
+        publish_date: pubDate.toISOString(),
+      },
+      overrideAccess: false,
+      user,
+    })
+    const { docs: [schedule] } = await findSchedule(draft.id)
+
+    expect(schedule.input).not.toHaveProperty('user')
+
+    await waitFor(1500)
+    await payload.jobs.run()
+
+    const publishedDraft = await payload.findByID({
+      collection: 'posts',
+      id: draft.id,
+    })
+
+    expect(publishedDraft._status).toBe('published')
+  })
+
+  it('fails a restricted user job when it executes as the scheduling user', async () => {
+    const user = await payload.create({
+      collection: 'users',
+      data: {
+        email: `user-scheduler-${Date.now()}@example.com`,
+        password: 'test-password',
+      },
+    })
+    const draft = await payload.create({
+      collection: 'posts',
+      data: {
+        title: 'user-access publish',
+      },
+      overrideAccess: false,
+      user,
+    })
+
+    await payload.jobs.queue({
+      input: {
+        doc: {
+          relationTo: 'posts',
+          value: String(draft.id),
+        },
+        type: 'publish',
+        user: user.id,
+      },
+      task: 'schedulePublish',
+      waitUntil: addSeconds(new Date(), 1),
+    } as Parameters<typeof payload.jobs.queue>[0])
+
+    await waitFor(1500)
+    await payload.jobs.run()
+
+    const unchangedDraft = await payload.findByID({
+      collection: 'posts',
+      id: draft.id,
+    })
+
+    expect(unchangedDraft._status).toBe('draft')
+  })
+
   it('handles subsequent draft updates to pending posts', async () => {
     const now = new Date()
     const pubDate = addMinutes(now, 5)

--- a/dev/test/syncSchedule.spec.ts
+++ b/dev/test/syncSchedule.spec.ts
@@ -3,16 +3,39 @@ import type { CollectionAfterChangeHook } from 'payload'
 import { normalizeScheduleConfig } from '../../src/config.js'
 import syncSchedule from '../../src/hooks/syncSchedule.js'
 
-const buildArgs = (data: Record<string, unknown>) => {
+const buildArgs = (
+  data: Record<string, unknown>,
+  {
+    executionAccess = 'user',
+    target = 'collection',
+    user = { id: 1 },
+  }: {
+    executionAccess?: 'override' | 'user'
+    target?: 'collection' | 'global'
+    user?: { id: number | string } | null
+  } = {},
+) => {
   const deleteMany = vi.fn().mockResolvedValue({ docs: [] })
   const queue = vi.fn().mockResolvedValue({ id: 'job-id' })
-  const hook = syncSchedule(normalizeScheduleConfig({ collections: ['posts'] })) as CollectionAfterChangeHook
+  const hook = syncSchedule(normalizeScheduleConfig({
+    collections: ['posts'],
+    executionAccess,
+    globals: ['home'],
+  })) as CollectionAfterChangeHook
 
   return {
     args: {
-      collection: {
-        slug: 'posts',
-      },
+      ...(target === 'global'
+        ? {
+            global: {
+              slug: 'home',
+            },
+          }
+        : {
+            collection: {
+              slug: 'posts',
+            },
+          }),
       doc: {
         id: 1,
         _status: 'draft',
@@ -34,9 +57,7 @@ const buildArgs = (data: Record<string, unknown>) => {
             error: vi.fn(),
           },
         },
-        user: {
-          id: 1,
-        },
+        user: user ?? undefined,
       },
     },
     deleteMany,
@@ -46,6 +67,70 @@ const buildArgs = (data: Record<string, unknown>) => {
 }
 
 describe('syncSchedule', () => {
+  it('stores the scheduling user in user-access jobs', async () => {
+    const publishDate = new Date(Date.now() + 60_000).toISOString()
+    const { args, hook, queue } = buildArgs({
+      publish_date: publishDate,
+    })
+
+    await hook(args as never)
+
+    expect(queue).toHaveBeenCalledWith(expect.objectContaining({
+      input: expect.objectContaining({
+        user: 1,
+      }),
+    }))
+  })
+
+  it('omits the scheduling user from override-access jobs', async () => {
+    const publishDate = new Date(Date.now() + 60_000).toISOString()
+    const { args, hook, queue } = buildArgs({
+      publish_date: publishDate,
+    }, {
+      executionAccess: 'override',
+    })
+
+    await hook(args as never)
+
+    expect(queue).toHaveBeenCalledWith(expect.objectContaining({
+      input: expect.not.objectContaining({
+        user: expect.anything(),
+      }),
+    }))
+  })
+
+  it('omits the scheduling user from override-access global jobs', async () => {
+    const publishDate = new Date(Date.now() + 60_000).toISOString()
+    const { args, hook, queue } = buildArgs({
+      publish_date: publishDate,
+    }, {
+      executionAccess: 'override',
+      target: 'global',
+    })
+
+    await hook(args as never)
+
+    expect(queue).toHaveBeenCalledWith(expect.objectContaining({
+      input: expect.not.objectContaining({
+        user: expect.anything(),
+      }),
+    }))
+  })
+
+  it('rejects user-access jobs without an authenticated user', async () => {
+    const publishDate = new Date(Date.now() + 60_000).toISOString()
+    const { args, hook, queue } = buildArgs({
+      publish_date: publishDate,
+    }, {
+      user: null,
+    })
+
+    await expect(hook(args as never)).rejects.toThrow(
+      'Cannot schedule a publish with executionAccess "user" without an authenticated user',
+    )
+    expect(queue).not.toHaveBeenCalled()
+  })
+
   it('omits timezone from schedulePublish job input by default', async () => {
     const publishDate = new Date(Date.now() + 60_000).toISOString()
     const { args, hook, queue } = buildArgs({

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,7 @@ const reservedPublishDateComponentSlots = Object.keys(publishDateComponents)
 
 export const defaultOpts: NormalizedScheduledPostConfig = {
   collections: [],
+  executionAccess: 'user',
   globals: [],
   interval: 5,
   publishDate: {
@@ -60,6 +61,7 @@ export const normalizeScheduleConfig = (
 
   return {
     collections: scheduleConfig.collections ? [...scheduleConfig.collections] : [...defaultOpts.collections],
+    executionAccess: scheduleConfig.executionAccess ?? defaultOpts.executionAccess,
     globals: scheduleConfig.globals ? [...scheduleConfig.globals] : [...defaultOpts.globals],
     interval,
     publishDate: {

--- a/src/hooks/syncSchedule.ts
+++ b/src/hooks/syncSchedule.ts
@@ -41,6 +41,19 @@ export default function syncSchedule(
     const previousPublishDateValue = previousDoc?.[publishDateFieldName]
     const publishInFuture = publishDateValue && new Date(publishDateValue) > new Date()
     const scheduleChanged = publishDateValue !== previousPublishDateValue
+
+    if (
+      !isPublishing &&
+      scheduleChanged &&
+      publishInFuture &&
+      scheduleConfig.executionAccess === 'user' &&
+      !req.user
+    ) {
+      throw new Error(
+        '[payload-plugin-scheduler] Cannot schedule a publish with executionAccess "user" without an authenticated user',
+      )
+    }
+
     try {
       if (isPublishing || scheduleChanged) {
         debug('Deleting previous schedule')
@@ -74,7 +87,6 @@ export default function syncSchedule(
           ? {
               global: slug,
               type: 'publish',
-              user: req.user?.id,
             }
           : {
               doc: {
@@ -82,8 +94,11 @@ export default function syncSchedule(
                 value: String(doc.id),
               },
               type: 'publish',
-              user: req.user?.id,
             }
+
+        if (scheduleConfig.executionAccess === 'user') {
+          input.user = req.user!.id
+        }
 
         if (typeof timezone === 'string') {
           input.timezone = timezone

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,9 @@
 export { SafeRelationship } from './fields/SafeRelationship/index.js'
 export { publishDate } from './fields/PublishDate/index.js'
 export { ScheduledPostPlugin } from './plugin.js'
-export type { PublishDateFieldOptions, SafeRelationshipField, ScheduledPostConfig } from './types.js'
+export type {
+  ExecutionAccess,
+  PublishDateFieldOptions,
+  SafeRelationshipField,
+  ScheduledPostConfig,
+} from './types.js'

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,8 +22,15 @@ export type PublishDateFieldOptions = Partial<Omit<DateField, 'admin' | 'timezon
 
 export type ManualPublishDateFieldOptions = Omit<PublishDateFieldOptions, 'name'>
 
+/**
+ * Controls whose access permissions Payload uses when the scheduled publish job executes.
+ * Use `override` to execute the job with `overrideAccess` set to `true`.
+ */
+export type ExecutionAccess = 'override' | 'user'
+
 export interface ScheduledPostConfig {
   collections?: string[]
+  executionAccess?: ExecutionAccess
   globals?: string[]
   interval?: number
   publishDate?: PublishDateFieldOptions
@@ -31,6 +38,7 @@ export interface ScheduledPostConfig {
 
 export type NormalizedScheduledPostConfig = {
   collections: string[]
+  executionAccess: ExecutionAccess
   globals: string[]
   interval: number
   publishDate: DateField


### PR DESCRIPTION
adds a new `executionAccess` arg that allows consumers to specify whether the schedule job inherits the current user's permissions or uses `overrideAccess`. 